### PR TITLE
Separates AppConfig sourced from file and ConfigMap

### DIFF
--- a/charts/backstage/templates/backstage-deployment.yaml
+++ b/charts/backstage/templates/backstage-deployment.yaml
@@ -23,8 +23,8 @@ spec:
         app.kubernetes.io/component: backstage
     spec:
       volumes:
-        {{- if .Values.backstage.extraAppConfig }}
-        {{- range .Values.backstage.extraAppConfig }}
+        {{- if .Values.backstage.appConfig.asConfigMap.enabled }}
+        {{- range .Values.backstage.appConfig.asConfigMap.appConfigAsConfigMap }}
         - name: {{ .configMapRef }}
           configMap:
             name: {{ .configMapRef }}
@@ -53,8 +53,14 @@ spec:
           {{- range .Values.backstage.args }}
             - {{ . | quote }}
           {{- end }}
-          {{- if .Values.backstage.extraAppConfig }}
-          {{- range .Values.backstage.extraAppConfig }}
+          {{- if .Values.backstage.appConfig.appConfigFile }}
+          {{- range .Values.backstage.appConfig.appConfigFile }}
+            - "--config"
+            - {{ .filename | quote }}
+          {{- end }}
+          {{- end }}
+          {{- if .Values.backstage.appConfig.asConfigMap.enabled }}
+          {{- range .Values.backstage.appConfig.asConfigMap.appConfigAsConfigMap }}
             - "--config"
             - {{ .filename | quote }}
           {{- end }}
@@ -68,8 +74,6 @@ spec:
             {{- end }}
           {{- end }}
           env:
-            - name: APP_CONFIG_backend_listen_port
-              value: {{ .Values.backstage.containerPorts.backend | quote }}
             {{- if .Values.postgresql.enabled }}
             - name: POSTGRES_HOST
               value: {{ include "backstage.postgresql.host" . }}
@@ -90,9 +94,9 @@ spec:
             - name: backend
               containerPort: {{ .Values.backstage.containerPorts.backend }}
               protocol: TCP
-          {{- if .Values.backstage.extraAppConfig }}
+          {{- if .Values.backstage.appConfig.asConfigMap.enabled }}
           volumeMounts:
-            {{- range .Values.backstage.extraAppConfig }}
+            {{- range .Values.backstage.appConfig.asConfigMap.appConfigAsConfigMap }}
             - name: {{ .configMapRef }}
               mountPath: "/app/{{ .filename }}"
               subPath: {{ .filename }} 

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -109,10 +109,38 @@ backstage:
     backend: 7007
   command: ["node", "packages/backend"]
   args: []
-  extraAppConfig: []
-  extraEnvVars: []
-  extraEnvVarsSecrets:
 
+  # -- AppConfig that you want your Backstage application to use
+  appConfig:
+
+    # -- AppConfig that you want to supply to your backstage application that is stored
+    # inside of a ConfigMap
+    asConfigMap:
+      enabled: false
+
+      # -- The different ConfigMaps to use for your AppConfig
+      # Example:
+      # appConfigAsConfigMap:
+      #   - configMapRef: my-dev-app-config 
+      #     filename: app-config.dev.yaml
+      #   - configMapRef: my-prod-app-config 
+      #     filename: app-config.prod.yaml
+      appConfigAsConfigMap:
+        - configMapRef: app-config-production
+          filename: app-config.production.yaml
+    
+    # -- AppConfig that you already have inside of the Backstage Image
+    # Example:
+    # appConfigFile:
+    # - filename: app-config.yaml
+    # - filename: app-config.production.yaml
+    appConfigFile:
+      - filename: app-config.yaml
+      - filename: app-config.production.yaml
+
+  extraEnvVars: []
+
+  extraEnvVarsSecrets: []
 ## @section Traffic Exposure parameters
 
 ## Service parameters


### PR DESCRIPTION
Splits out the AppConfig sourced from files packaged inside the container and those source from ConfigMaps.

Addresses: https://github.com/vinzscam/backstage-chart/issues/4

Signed-off-by: ChrisJBurns <29541485+ChrisJBurns@users.noreply.github.com>