### PR TITLE
feat: allow to define extra volumes and volume mounts in deployment

### DIFF
--- a/charts/backstage/templates/backstage-deployment.yaml
+++ b/charts/backstage/templates/backstage-deployment.yaml
@@ -26,12 +26,15 @@ spec:
         app.kubernetes.io/component: backstage
     spec:
       volumes:
-        {{- if .Values.backstage.extraAppConfig }}
+        {{- if (or .Values.backstage.extraAppConfig (and .Values.backstage.extraVolumeMounts .Values.backstage.extraVolumes)) }}
         {{- range .Values.backstage.extraAppConfig }}
         - name: {{ .configMapRef }}
           configMap:
             name: {{ .configMapRef }}
         {{- end }}            
+        {{- if .Values.backstage.extraVolumes }}
+          {{- toYaml .Values.backstage.extraVolumes | nindent 8 }}
+        {{- end }}
         {{- end }}
       {{- if .Values.backstage.image.pullSecrets }}
       imagePullSecrets:
@@ -93,11 +96,14 @@ spec:
             - name: backend
               containerPort: {{ .Values.backstage.containerPorts.backend }}
               protocol: TCP
-          {{- if .Values.backstage.extraAppConfig }}
+          {{- if (or .Values.backstage.extraAppConfig (and .Values.backstage.extraVolumeMounts .Values.backstage.extraVolumes)) }}
           volumeMounts:
             {{- range .Values.backstage.extraAppConfig }}
             - name: {{ .configMapRef }}
               mountPath: "/app/{{ .filename }}"
               subPath: {{ .filename }} 
+            {{- end }}
+            {{- if .Values.backstage.extraVolumeMounts }}
+              {{- toYaml .Values.backstage.extraVolumeMounts | nindent 12 }}
             {{- end }}
           {{- end }}

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -112,6 +112,8 @@ backstage:
   extraAppConfig: []
   extraEnvVars: []
   extraEnvVarsSecrets:
+  extraVolumeMounts: []
+  extraVolumes: []
 
 ## @section Traffic Exposure parameters
 


### PR DESCRIPTION
Hi!

First of all, thanks a lot for the work done here! 😃 

I am starting to use your Helm Chart to follow a standard instead of having my own.

In my case, I retrieve secrets from Azure Key Vault using the [Azure Key Vault Provider for Secrets Store CSI Driver](https://learn.microsoft.com/en-us/azure/aks/csi-secrets-store-driver) which is using a standard approach from the K8s community: https://github.com/kubernetes-sigs/secrets-store-csi-driver

To be able to mount secrets using this provider, it is required mounting the CSI driver in a pod.

In order to allow that, and probably other use cases, we can just allow defining extra volumes and volume mounts.

Please, if there is anything else to be done, just let me know :)