### PR TITLE
feat: define extra app config which generates ConfigMap

### DIFF
--- a/charts/backstage/templates/app-config-configmap.yaml
+++ b/charts/backstage/templates/app-config-configmap.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.backstage.extraAppConfigToConfigMap }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: backstage-app-config
+data:
+  app-config.yaml: {{ toYaml .Values.backstage.extraAppConfigToConfigMap | indent 2 }}
+{{- end }}

--- a/charts/backstage/templates/backstage-deployment.yaml
+++ b/charts/backstage/templates/backstage-deployment.yaml
@@ -31,7 +31,12 @@ spec:
         - name: {{ .configMapRef }}
           configMap:
             name: {{ .configMapRef }}
-        {{- end }}            
+        {{- end }}
+        {{- end }}
+        {{- if .Values.backstage.extraAppConfigToConfigMap }}
+        - configMap:
+            name: backstage-app-config
+          name: backstage-app-config
         {{- end }}
       {{- if .Values.backstage.image.pullSecrets }}
       imagePullSecrets:
@@ -61,6 +66,10 @@ spec:
             - "--config"
             - {{ .filename | quote }}
           {{- end }}
+          {{- end }}
+          {{- if .Values.backstage.extraAppConfigToConfigMap }}
+            - "--config"
+            - "app-config-from-configmap.yaml"
           {{- end }}
           {{- end }}
           {{- if .Values.backstage.extraEnvVarsSecrets }}
@@ -93,11 +102,16 @@ spec:
             - name: backend
               containerPort: {{ .Values.backstage.containerPorts.backend }}
               protocol: TCP
-          {{- if .Values.backstage.extraAppConfig }}
+          {{- if (or .Values.backstage.extraAppConfig .Values.backstage.extraAppConfigToConfigMap) }}
           volumeMounts:
             {{- range .Values.backstage.extraAppConfig }}
             - name: {{ .configMapRef }}
               mountPath: "/app/{{ .filename }}"
               subPath: {{ .filename }} 
+            {{- end }}
+            {{- if .Values.backstage.extraAppConfigToConfigMap }}
+            - name: backstage-app-config
+              mountPath: /app/app-config-from-configmap.yaml
+              subPath: app-config.yaml
             {{- end }}
           {{- end }}

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -113,6 +113,12 @@ backstage:
   extraEnvVars: []
   extraEnvVarsSecrets:
 
+  # E.g:
+  # extraAppConfigToConfigMap: |
+  #   app:
+  #     baseUrl: https://somedomain.tld
+  extraAppConfigToConfigMap: null
+
 ## @section Traffic Exposure parameters
 
 ## Service parameters


### PR DESCRIPTION
As it was been discussed a little bit at https://github.com/vinzscam/backstage-chart/issues/4:

I think it would be nice to give the possibility to define an extra app config file in the values.yaml, which then creates a ConfigMap automatically, mounts it and uses it in the config.

Please, let me know your thoughts, and if there is anything I should improve or change. :)