### PR TITLE
Adds Github Actions for PR workflow

### DIFF
--- a/.github/workflows/codespell.yaml
+++ b/.github/workflows/codespell.yaml
@@ -1,0 +1,20 @@
+name: Codespell
+
+# Documentation:
+# https://help.github.com/en/articles/workflow-syntax-for-github-actions
+
+on: pull_request
+
+jobs:
+  codespell:
+    name: Codespell
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+      - name: Codespell
+        uses: codespell-project/actions-codespell@master
+        with:
+          skip: .git
+          check_filenames: true
+          check_hidden: true

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -1,0 +1,48 @@
+name: Lint and Test Charts
+
+on: pull_request
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: 3.10.1
+
+      - name: Add dependencies
+        run: |
+          helm repo add bitnami https://charts.bitnami.com/bitnami
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.1.0
+
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }})
+          if [[ -n "$changed" ]]; then
+            echo "::set-output name=changed::true"
+          fi
+      
+      - name: Run chart-testing (lint)
+        run: ct lint --target-branch ${{ github.event.repository.default_branch }} --validate-maintainers=false
+        if: steps.list-changed.outputs.changed == 'true'
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.2.0
+        if: steps.list-changed.outputs.changed == 'true'
+
+      - name: Run chart-testing (install) for Backstage
+        run: ct install --target-branch ${{ github.event.repository.default_branch }}
+        if: steps.list-changed.outputs.changed == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,9 +18,11 @@ jobs:
         run: |
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
       - name: Add dependencies
         run: |
           helm repo add bitnami https://charts.bitnami.com/bitnami
+          
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.4.0
         env:


### PR DESCRIPTION
As described in https://github.com/vinzscam/backstage-chart/issues/21 we do not currently have any automated tests triggered when we make Helm Chart changes. This PR adds a simple lint and e2e test for the Backstage chart, so that we at least know if we make any breaking changes that stop the Chart installation - further reducing the need for manual efforts.

An additional point, it will also fail the PR Github Workflow if the Chart version hasn't been bumped up - this reduces the need for manual commits later on to bump the Chart versions.

Signed-off-by: ChrisJBurns <29541485+ChrisJBurns@users.noreply.github.com>