### PR TITLE
Fix: Allow only setting annotations on service

### DIFF
--- a/charts/backstage/templates/service.yaml
+++ b/charts/backstage/templates/service.yaml
@@ -8,14 +8,14 @@ metadata:
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
-  {{- if .Values.commonAnnotations }}
+  {{- if or .Values.commonAnnotations .Values.service.annotations }}
   annotations:
     {{- if .Values.service.annotations }}
-    {{ include "common.tplvalues.render" ( dict "value" .Values.service.annotations "context" $) | nindent 4 }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.service.annotations "context" $) | nindent 4 }}
     {{- end }}
     {{- if .Values.commonAnnotations }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
-    {{- end }}  
+    {{- end }}
   {{- end }}
 spec:
   type: {{ .Values.service.type }}


### PR DESCRIPTION
Previously you had to include `commonAnnotations`, this allows you to only specify `service.annotations`

Also removes the extra spacing between the `annotations` block and the first annotation