### PR TITLE
fix: Make default values for backstage.args match docs

### DIFF
--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -108,7 +108,7 @@ backstage:
   containerPorts:
     backend: 7007
   command: ["node", "packages/backend"]
-  args: []
+  args: ["--config", "app-config.yaml", "--config", "app-config.production.yaml"]
   extraAppConfig: []
   extraEnvVars: []
   extraEnvVarsSecrets:


### PR DESCRIPTION
https://github.com/vinzscam/backstage-chart/blob/d74842c24c7946ede76d8017c9fb7d01b7aae405/README.md?plain=1#L81